### PR TITLE
Fix missing return in tok_begin

### DIFF
--- a/tfkit/utility/tok.py
+++ b/tfkit/utility/tok.py
@@ -11,7 +11,7 @@ def tok_begin(tokenizer):
     if tokenizer.special_tokens_map.get('bos_token') is not None:
         return tokenizer.special_tokens_map.get('bos_token')
     elif tokenizer.special_tokens_map.get('cls_token') is not None:
-        tokenizer.special_tokens_map.get('cls_token')
+        return tokenizer.special_tokens_map.get('cls_token')
     return 'cls'
 
 


### PR DESCRIPTION
## Summary
- ensure `tok_begin` returns the CLS token when BOS token is missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686147ef8518832aa72c8d4bce37ddc4