### PR TITLE
Fix classifier text

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ tfkit-train \
 --lr 4e-5 \
 --maxlen 384 \
 --epoch 10 \
---savedir roberta_sentiment_classificer
+--savedir roberta_sentiment_classifier
 ```
 
 ### Step 3: Evaluate
 ```bash
 tfkit-eval \
---task roberta_sentiment_classificer/1.pt \
+--task roberta_sentiment_classifier/1.pt \
 --metric clas \
 --valid testing_data.csv
 ```
@@ -90,7 +90,7 @@ tfkit-eval \
     --lr 4e-5 \
     --maxlen 384 \
     --epoch 10 \
-    --savedir roberta_sentiment_classificer_multi_task
+    --savedir roberta_sentiment_classifier_multi_task
   ```
 </details>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,7 @@ tfkit-train \
 --lr 4e-5 \
 --maxlen 384 \
 --epoch 10 \
---savedir roberta_sentiment_classificer
+--savedir roberta_sentiment_classifier
 ```
 
 #### Third step - model eval


### PR DESCRIPTION
## Summary
- correct `classificer` to `classifier` in docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_686149295b5c832abeb0282cf96d952b