### PR TITLE
Fix WER/CER empty target handling

### DIFF
--- a/tfkit/test/utility/test_utility_eval_metric.py
+++ b/tfkit/test/utility/test_utility_eval_metric.py
@@ -151,6 +151,24 @@ class TestEval(unittest.TestCase):
         eval = tfkit.utility.eval_metric.EvalMetric(tokenizer, normalize_text=True)
         self.assertEqual(eval.tokenize_text("How's this work"), "how ' s this work")
 
+    def test_empty_er(self):
+        class DummyTokenizer:
+            special_tokens_map = {'sep_token': '[SEP]'}
+
+            def encode(self, text, add_special_tokens=False):
+                return text.split()
+
+            def decode(self, tokens, **kwargs):
+                return ' '.join(tokens)
+
+        tokenizer = DummyTokenizer()
+        eval = tfkit.utility.eval_metric.EvalMetric(tokenizer)
+        eval.add_record("", "", "", task='default')
+        results = list(eval.cal_score('er'))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0][1]['WER'], 0)
+        self.assertEqual(results[0][1]['CER'], 0)
+
     @pytest.mark.skip()
     def testNLGWithPAD(self):
         tokenizer = BertTokenizer.from_pretrained('voidful/albert_chinese_tiny')

--- a/tfkit/utility/eval_metric.py
+++ b/tfkit/utility/eval_metric.py
@@ -195,8 +195,8 @@ class EvalMetric:
                     targets.append(target)
                     data_score.append([predict, target, {'wer': wer, 'cer': cer}])
 
-                wer = 100 * _wer(targets, predicts) if len(target) > 0 else 100
-                cer = 100 * _cer(targets, predicts) if len(target) > 0 else 100
+                wer = 100 * _wer(targets, predicts) if len(targets) > 0 else 100
+                cer = 100 * _cer(targets, predicts) if len(targets) > 0 else 100
                 result = {"WER": wer, "CER": cer}
                 data_score = sorted(data_score, key=lambda i: i[2]['wer'], reverse=False)
             if "nlg" in metric:


### PR DESCRIPTION
## Summary
- handle global WER/CER when there is no target text
- test EvalMetric on empty input

## Testing
- `pytest tfkit/test/utility/test_utility_eval_metric.py::TestEval.test_empty_er -q` *(fails: ModuleNotFoundError: No module named 'tfkit')*

------
https://chatgpt.com/codex/tasks/task_e_6861492aee08832a9947b6181e28646d