### PR TITLE
Fix documentation typos

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ The key to combine different task together is to make different task with same d
 **notice**  
 
 * All data will be in csv format - tfkit will use **csv** for all task, normally it will have two columns, first columns is the input of models, the second column is the output of models.
-* Plane text with no tokenization - there is no need to tokenize text before training, or do re-calculating for tokenization, tfkit will handle it for you.
+* Plain text with no tokenization - there is no need to tokenize text before training, or do re-calculating for tokenization, tfkit will handle it for you.
 * No header is needed.
 
 For example, a sentiment classification dataset will be like:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@ pip install .
 ```
 
 ## Running tfkit
-Model you've installed tfkit, you can run with  
+Once you’ve installed tfkit, you can run with
 
 ### pip installed version: 
 `tfkit-train`   


### PR DESCRIPTION
## Summary
- fix wording in installation guide
- fix typo in index page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tfkit')*

------
https://chatgpt.com/codex/tasks/task_e_6861492c102c832a97adfcfe0056d416