### PR TITLE
Rename roberta tokenization test

### DIFF
--- a/tfkit/test/utility/test_utility_tok.py
+++ b/tfkit/test/utility/test_utility_tok.py
@@ -24,7 +24,7 @@ class TestTok(unittest.TestCase):
         pad = tfkit.utility.tok.tok_pad(tokenizer)
         self.assertEqual(pad, "[PAD]")
 
-    def testTok(self):
+    def testTok_roberta(self):
         tokenizer = AutoTokenizer.from_pretrained('distilroberta-base')
         begin = tfkit.utility.tok.tok_begin(tokenizer)
         self.assertEqual(begin, "<s>")


### PR DESCRIPTION
## Summary
- rename duplicate `testTok` to `testTok_roberta`
- run tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_6861492cf208832a9e5a606b5fa554ee